### PR TITLE
Add --socket=cups for printing support

### DIFF
--- a/org.kde.kolourpaint.json
+++ b/org.kde.kolourpaint.json
@@ -7,6 +7,7 @@
    "rename-icon": "kolourpaint",
    "finish-args": [
       "--share=ipc",
+      "--socket=cups",
       "--socket=x11",
       "--socket=wayland",
       "--device=dri",


### PR DESCRIPTION
This will allow us to print with Flatpak 1.6 (once released).