### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kolourpaint.json
+++ b/org.kde.kolourpaint.json
@@ -18,6 +18,7 @@
         "/include",
         "/lib/cmake",
         "/lib/plugins/designer",
+        "/share/doc",
         "/share/man"
     ],
     "modules": [


### PR DESCRIPTION
### Total

The installed size reduced from 7.8 MB to 2.4 MB.

KDE apps usually open an external website for help documentation.

This app uses the following page:

https://docs.kde.org/stable_kf6/en/kolourpaint/kolourpaint/index.html

Therefore, it's not required to keep the /share/doc folder.